### PR TITLE
Update test patterns in .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -2,6 +2,8 @@ version = 1
 
 test_patterns = ["tests/**"]
 
+exclude_patterns = ["**/examples/**"]
+
 [[analyzers]]
 name = "python"
 enabled = true

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,6 @@
 version = 1
 
-test_patterns = ["tests/*"]
+test_patterns = ["tests/**"]
 
 [[analyzers]]
 name = "python"


### PR DESCRIPTION
The glob pattern should match all subdirectories inside the `tests/` dir. Hence, `tests/**`.